### PR TITLE
Part 1 : Make unit test pass

### DIFF
--- a/part 1/test.js
+++ b/part 1/test.js
@@ -5,10 +5,10 @@ it("works", () => {
       input: {
         a: {
           b: {
-            c: "z"
+            c: "z",
+            d: "y"
           }
-        },
-        "a.b.d": "y"
+        }
       },
       output: {
         a: {


### PR DESCRIPTION
Supposing ```./resolveObjects.js``` works as expected and throws no errors.


What makes the test fail is that
```javascript
x["a.b.d"]
``` 
is not the same as 
```javascript 
x.a.b.d
```

Bellow is the change required to pass the test (https://github.com/OussamaRomdhane/javascript-test/commit/32c1121dfd08eeb70be48126e78525a6509b2b5c) 